### PR TITLE
Retirando pesquisa na pagina de user

### DIFF
--- a/react-app/src/pages/ChamadoU.jsx
+++ b/react-app/src/pages/ChamadoU.jsx
@@ -33,10 +33,6 @@ const ChamadoU = () => {
     <center><Titulo>Planilha de Chamados</Titulo></center>
    
     <br />
-    
-    <center>
-    <Busca type='text' onChange={(e) => filtra(e.target.value)}/>
-    </center>
 
    {
     info.map(


### PR DESCRIPTION
Retirada a aba de pesquisa na página de usuário, já que ele só veria os chamados abertos do seu próprio setor.